### PR TITLE
Update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ node_js:
 matrix:
     fast_finish: true
     allow_failures:
-        - node_js: 6
 env:
   global:
     - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
 node_js:
   - 0.12
   - 4
-  - 5
   - 6
 matrix:
     fast_finish: true


### PR DESCRIPTION
- Remove Node.js v5
- Require tests to pass on Node.js v6

Fixes https://github.com/pelias/pelias/issues/401
Connects https://github.com/pelias/pelias/issues/334
